### PR TITLE
字符编码转换

### DIFF
--- a/src/test_basic/main.cpp
+++ b/src/test_basic/main.cpp
@@ -318,6 +318,11 @@ void test_encode()
     std::wstring sHello1(L"helloÄãºÃ");
     std::string sHello2 = zl::WideToUTF8(sHello1);
     std::wstring sHello3 = zl::UTF8ToWide(sHello2);
+    assert(sHello1 == sHello3);
+
+    std::string s1 = "helloÄãºÃ";
+    std::string s2 = zl::GbkToUtf8(s1);
+    assert(s1 == zl::Utf8ToGbk(s2));
 }
 
 void test_hashtable()


### PR DESCRIPTION
1, 使用string.resize()减少new的调用
2，增加了utf8与gbk之间的转换
3，static修改为inline
