### PR TITLE
* 修改字符串转换的一个bug

### DIFF
--- a/pellets/z_win_utils/str_conv.hpp
+++ b/pellets/z_win_utils/str_conv.hpp
@@ -73,7 +73,7 @@ inline CStringW ZLStrConv::a2w(LPCSTR lpBuf, UINT uCodePage, int nBufLen)
         BOOL bSuc = (0 < ::MultiByteToWideChar(uCodePage, 0, lpBuf, nBufLen, pResult, nDstLen));
         if (bSuc)
         {
-            sRetW.Append(pResult, nDstLen);
+            sRetW.Append(pResult, nDstLen - 1);
         }
         delete[] pResult;
     }
@@ -90,7 +90,7 @@ inline CStringA ZLStrConv::w2a( LPCWSTR lpBuf, UINT uCodePage, int nBufLen )
         BOOL bSuc = (0 < ::WideCharToMultiByte( uCodePage, 0, lpBuf, nBufLen, pResult, nDstLen, NULL, NULL ));
         if (bSuc)
         {
-            sRetA.Append(pResult, nDstLen);
+            sRetA.Append(pResult, nDstLen - 1);
         }
         delete[] pResult;
     }


### PR DESCRIPTION
MultiByteToWideChar系列函数的返回数值,包含了结果的结尾的'\0',
vs2013下使用Append(psz, len),后面的len是被无视的,所以单元测试通过
vs2005下使用,导致转换后的字符串,后面多了一个'\0'.
